### PR TITLE
Fix nested options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
-# serde-evaluate
+# Serde Evaluate
 
-Extract single scalar field values from Serializeable structs without full deserialization.
+[![Crates.io](https://img.shields.io/crates/v/serde_evaluate.svg)](https://crates.io/crates/serde_evaluate)
+[![Docs.rs](https://docs.rs/serde_evaluate/badge.svg)](https://docs.rs/serde_evaluate)
+
+Extract single scalar field values from Serializable structs without full deserialization.
+
+## Overview
+
+This library provides a mechanism to extract the value of a single field
+from any struct that implements `serde::Serialize` **without** needing to
+deserialize the entire struct. The extraction happens at **runtime** by
+intercepting the serialization process.
+It's particularly useful when you only need one specific piece of data
+from a potentially large or complex structure, potentially residing
+within nested structs or maps.
+
+The extracted value is returned as a `FieldScalarValue` enum, which covers
+common scalar types (integers, floats, bool, string, char, bytes, unit, and options of these).

--- a/README.md
+++ b/README.md
@@ -17,3 +17,83 @@ within nested structs or maps.
 
 The extracted value is returned as a `FieldScalarValue` enum, which covers
 common scalar types (integers, floats, bool, string, char, bytes, unit, and options of these).
+
+## Basic Usage
+
+For extracting simple top-level fields, use `FieldExtractor`:
+
+```rust
+use serde::Serialize;
+use serde_evaluate::{extractor::FieldExtractor, value::FieldScalarValue, EvaluateError};
+
+#[derive(Serialize)]
+struct UserProfile {
+    user_id: u64,
+    username: String,
+    is_active: bool,
+}
+
+fn main() -> Result<(), EvaluateError> {
+    let profile = UserProfile {
+        user_id: 9876,
+        username: "tester".to_string(),
+        is_active: true,
+    };
+
+    // Extract the 'username' field (top-level)
+    let extractor = FieldExtractor::new("username");
+    let username_value = extractor.evaluate(&profile)?;
+    assert_eq!(username_value, FieldScalarValue::String("tester".to_string()));
+
+    // Extract the 'is_active' field (top-level)
+    let active_extractor = FieldExtractor::new("is_active");
+    let active_value = active_extractor.evaluate(&profile)?;
+    assert_eq!(active_value, FieldScalarValue::Bool(true));
+
+    Ok(())
+}
+```
+
+For nested fields (within structs or maps), use `NestedFieldExtractor`. Here's an example demonstrating how to extract a nested field from a `HashMap`:
+
+```rust
+use serde::Serialize;
+use std::collections::HashMap;
+use serde_evaluate::{extractor::NestedFieldExtractor, value::FieldScalarValue, EvaluateError};
+
+#[derive(Serialize)]
+struct Config {
+    port: u16,
+    settings: HashMap<String, Detail>,
+}
+
+#[derive(Serialize)]
+struct Detail {
+    enabled: bool,
+    level: String,
+}
+
+fn main() -> Result<(), EvaluateError> {
+    let mut settings_map = HashMap::new();
+    settings_map.insert("feature_x".to_string(), Detail { enabled: true, level: "debug".to_string() });
+    settings_map.insert("feature_y".to_string(), Detail { enabled: false, level: "info".to_string() });
+
+    let config = Config {
+        port: 8080,
+        settings: settings_map,
+    };
+
+    // Extract 'settings[feature_x].level'
+    // The path components are: "settings", "feature_x", "level"
+    let extractor = NestedFieldExtractor::new_from_path(&["settings", "feature_x", "level"])?;
+    let level_value = extractor.evaluate(&config)?;
+    assert_eq!(level_value, FieldScalarValue::String("debug".to_string()));
+
+    // Extract 'settings[feature_y].enabled'
+    // The path components are: "settings", "feature_y", "enabled"
+    let extractor_enabled = NestedFieldExtractor::new_from_path(&["settings", "feature_y", "enabled"])?;
+    let enabled_value = extractor_enabled.evaluate(&config)?;
+    assert_eq!(enabled_value, FieldScalarValue::Bool(false));
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,86 @@
 //!
 //! ## Usage
 //!
+//! For extracting simple top-level fields, use `FieldExtractor`:
+//! ```rust
+//! use serde::Serialize;
+//! use serde_evaluate::{extractor::FieldExtractor, value::FieldScalarValue, EvaluateError};
+//!
+//! #[derive(Serialize)]
+//! struct UserProfile {
+//!     user_id: u64,
+//!     username: String,
+//!     is_active: bool,
+//! }
+//!
+//! fn main() -> Result<(), EvaluateError> {
+//!     let profile = UserProfile {
+//!         user_id: 9876,
+//!         username: "tester".to_string(),
+//!         is_active: true,
+//!     };
+//!
+//!     // Extract the 'username' field (top-level)
+//!     let extractor = FieldExtractor::new("username");
+//!     let username_value = extractor.evaluate(&profile)?;
+//!     assert_eq!(username_value, FieldScalarValue::String("tester".to_string()));
+//!
+//!     // Extract the 'is_active' field (top-level)
+//!     let active_extractor = FieldExtractor::new("is_active");
+//!     let active_value = active_extractor.evaluate(&profile)?;
+//!     assert_eq!(active_value, FieldScalarValue::Bool(true));
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! For nested fields (within structs or maps), use `NestedFieldExtractor`. Here's a simple example extracting a nested field from a map:
+//!
+//! ```rust
+//! use serde::Serialize;
+//! use std::collections::HashMap;
+//! use serde_evaluate::{extractor::NestedFieldExtractor, value::FieldScalarValue, EvaluateError};
+//!
+//! #[derive(Serialize)]
+//! struct Config {
+//!     port: u16,
+//!     settings: HashMap<String, Detail>,
+//! }
+//!
+//! #[derive(Serialize)]
+//! struct Detail {
+//!     enabled: bool,
+//!     level: String,
+//! }
+//!
+//! fn main() -> Result<(), EvaluateError> {
+//!     let mut settings_map = HashMap::new();
+//!     settings_map.insert("feature_x".to_string(), Detail { enabled: true, level: "debug".to_string() });
+//!     settings_map.insert("feature_y".to_string(), Detail { enabled: false, level: "info".to_string() });
+//!
+//!     let config = Config {
+//!         port: 8080,
+//!         settings: settings_map,
+//!     };
+//!
+//!     // Extract 'settings[feature_x].level'
+//!     // The path components are: "settings", "feature_x", "level"
+//!     let extractor = NestedFieldExtractor::new_from_path(&["settings", "feature_x", "level"])?;
+//!     let level_value = extractor.evaluate(&config)?;
+//!     assert_eq!(level_value, FieldScalarValue::String("debug".to_string()));
+//!
+//!     // Extract 'settings[feature_y].enabled'
+//!     // The path components are: "settings", "feature_y", "enabled"
+//!     let extractor_enabled = NestedFieldExtractor::new_from_path(&["settings", "feature_y", "enabled"])?;
+//!     let enabled_value = extractor_enabled.evaluate(&config)?;
+//!     assert_eq!(enabled_value, FieldScalarValue::Bool(false));
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! And a more comprehensive example showing various features:
+//!
 //! ```rust
 //! use serde::Serialize;
 //! use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,16 @@
 //! The extracted value is returned as a `FieldScalarValue` enum, which covers
 //! common scalar types (integers, floats, bool, string, char, bytes, unit, and options of these).
 //!
+//! ## Features
+//!
+//! *   **Extract Scalar Fields:** Retrieve basic scalar types (integers, floats, bool, char, String) from any level of a struct or map.
+//! *   **Nested Field Access:** Access fields within nested structs or maps using dot (`.`) or index (`[key]`) notation (e.g., `"outer.inner.field"`, `"map[key].field"`).
+//! *   **Option Handling:**
+//!     *   `Option<Scalar>`: Correctly extracts as `Some(Scalar)` or `None`.
+//!     *   `Option<Option<Scalar>>`: Extracts nested `Option` types (e.g., `Some(Some(Scalar))`, `Some(None)`, `None`).
+//! *   **Bytes Support:** Extracts `Vec<u8>` when annotated with `#[serde(with = "serde_bytes")]`.
+//! *   **Error Handling:** Returns specific errors for unsupported types (`UnsupportedType`) or missing fields (`FieldNotFound`, `NestedFieldNotFound`).
+//!
 //! ## How it Works
 //!
 //! It uses a custom Serde `Serializer` (`FieldValueExtractorSerializer`) that intercepts
@@ -141,8 +151,7 @@
 //!
 //!     Ok(())
 //! }
-//! ```
-//!
+//! 
 //! ## Supported Types
 //!
 //! The final target of the extraction path must be one of the following types

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 //! This library provides a mechanism to extract the value of a single field
 //! from any struct that implements `serde::Serialize` **without** needing to
-//! deserialize the entire struct. It's particularly useful when you only need
-//! one specific piece of data from a potentially large or complex structure,
-//! potentially residing within nested structs or maps.
+//! deserialize the entire struct. The extraction happens at **runtime** by
+//! intercepting the serialization process.
+//! It's particularly useful when you only need one specific piece of data
+//! from a potentially large or complex structure, potentially residing
+//! within nested structs or maps.
 //!
 //! The extracted value is returned as a `FieldScalarValue` enum, which covers
 //! common scalar types (integers, floats, bool, string, char, bytes, unit, and options of these).
@@ -151,7 +153,8 @@
 //!
 //!     Ok(())
 //! }
-//! 
+//! ```
+//!
 //! ## Supported Types
 //!
 //! The final target of the extraction path must be one of the following types

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,7 +1,16 @@
 use crate::error::EvaluateError;
 use crate::value::FieldScalarValue;
-use serde::ser::{self /*, SerializeStruct */}; // Removed unused import
+use serde::ser::{self};
 use serde::{Serialize, Serializer};
+
+// Helper function to wrap a value in N levels of Option(Some(...))
+fn wrap_in_options(value: FieldScalarValue, level: u8) -> FieldScalarValue {
+    let mut current = value;
+    for _ in 0..level {
+        current = FieldScalarValue::Option(Some(Box::new(current)));
+    }
+    current
+}
 
 // Define a dummy struct to handle skipping compound types
 pub(crate) struct Skip;
@@ -77,15 +86,16 @@ impl ser::SerializeSeq for Skip {
     }
 }
 
+// -----------------------------------------------------------------------------
+
 // Custom Serializer Implementation Struct
-// This struct drives the serialization process, looking for the target field path.
 pub(crate) struct FieldValueExtractorSerializer {
-    path: Vec<String>,                   // The full path to the target field
-    current_path_index: usize,           // Current index/depth in the path traversal
-    capturing: bool, // True if the next value should be captured (at the final path segment)
-    expecting_option_inner: bool, // True if inside a Some() variant and capturing
-    result: Option<FieldScalarValue>, // Stores the final extracted value
+    path: Vec<String>,                   // Target path segments
+    current_path_index: usize,           // Current depth in the path traversal
+    value: Option<FieldScalarValue>,     // Stores the final extracted value
     current_map_key_match: Option<bool>, // Tracks if the current map key matched the path segment
+    ready_to_capture: bool, // True if the *next* serialize_* call is for the final target value
+    option_nesting_level: u8, // Tracks nesting level when capturing Option<Option<...>>
 }
 
 // Implement helper methods for the serializer
@@ -100,48 +110,35 @@ impl FieldValueExtractorSerializer {
     pub(crate) fn new_nested(path_segments: Vec<String>) -> Self {
         FieldValueExtractorSerializer {
             path: path_segments,
-            current_path_index: 0, // Start at the beginning of the path
-            capturing: false,      // Not capturing initially
-            expecting_option_inner: false,
-            result: None,
-            current_map_key_match: None, // Initialize map key match state
+            current_path_index: 0,
+            value: None,
+            current_map_key_match: None,
+            ready_to_capture: false, // Initialize flags
+            option_nesting_level: 0,
         }
     }
 
-    // Called by individual serialize_* methods.
-    // If capturing is true, stores the value (wrapping in Option if needed)
-    // and resets flags.
-    // This needs update to check current_path_index vs path.len()
-    fn capture_value(&mut self, value: FieldScalarValue) {
-        if self.capturing {
-            // Only capture if we have reached the end of the specified path.
-            if self.current_path_index == self.path.len() {
-                self.result = if self.expecting_option_inner {
-                    Some(FieldScalarValue::Option(Some(Box::new(value))))
-                } else {
-                    Some(value)
-                };
-                // Reset flags after successful capture at the correct path depth.
-                self.capturing = false;
-                self.expecting_option_inner = false;
-            } else {
-                // If capturing is true but index hasn't reached the end, it's an internal logic error
-                // in how capturing was set (likely in serialize_field or serialize_some).
-                // Reset flags defensively, but don't store the value.
-                self.capturing = false;
-                self.expecting_option_inner = false;
-            }
+    // Called by individual scalar serialize_* methods.
+    // Captures the value if ready_to_capture flag is set,
+    // potentially wrapping based on option_nesting_level.
+    fn capture_value(&mut self, value: FieldScalarValue) -> Result<(), EvaluateError> {
+        if self.ready_to_capture {
+            // Wrap the value according to the current nesting level.
+            self.value = Some(wrap_in_options(value, self.option_nesting_level));
+            // Reset nesting level? No, let serialize_some handle decrementing.
+            // Do not reset ready_to_capture here; the caller (serialize_field/value) manages it.
         }
+        // If not ready_to_capture, do nothing.
+        Ok(())
     }
 
     pub(crate) fn into_result(self) -> Option<FieldScalarValue> {
-        self.result
+        self.value
     }
 }
 
-// Implement the Serializer trait
-// Delegates most primitive types to capture_value.
-// Handles Option and compound types specifically.
+// Implement the main Serializer trait for our extractor
+// Most methods either delegate to capture_value, handle path traversal, or return UnsupportedType/Skip.
 impl Serializer for &mut FieldValueExtractorSerializer {
     type Ok = ();
     type Error = EvaluateError;
@@ -155,122 +152,109 @@ impl Serializer for &mut FieldValueExtractorSerializer {
     type SerializeStructVariant = serde::ser::Impossible<Self::Ok, Self::Error>;
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::Bool(v));
-        Ok(())
+        self.capture_value(FieldScalarValue::Bool(v))
     }
 
     fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::I8(v));
-        Ok(())
+        self.capture_value(FieldScalarValue::I8(v))
     }
 
     fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::I16(v));
-        Ok(())
+        self.capture_value(FieldScalarValue::I16(v))
     }
 
     fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::I32(v));
-        Ok(())
+        self.capture_value(FieldScalarValue::I32(v))
     }
 
     fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::I64(v));
-        Ok(())
+        self.capture_value(FieldScalarValue::I64(v))
     }
 
     fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::I128(v));
-        Ok(())
+        self.capture_value(FieldScalarValue::I128(v))
     }
 
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::U8(v));
-        Ok(())
+        self.capture_value(FieldScalarValue::U8(v))
     }
 
     fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::U16(v));
-        Ok(())
+        self.capture_value(FieldScalarValue::U16(v))
     }
 
     fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::U32(v));
-        Ok(())
+        self.capture_value(FieldScalarValue::U32(v))
     }
 
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::U64(v));
-        Ok(())
+        self.capture_value(FieldScalarValue::U64(v))
     }
 
     fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::U128(v));
-        Ok(())
+        self.capture_value(FieldScalarValue::U128(v))
     }
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::F32(v));
-        Ok(())
+        self.capture_value(FieldScalarValue::F32(v))
     }
 
     fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::F64(v));
-        Ok(())
+        self.capture_value(FieldScalarValue::F64(v))
     }
 
     fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::Char(v));
-        Ok(())
+        self.capture_value(FieldScalarValue::Char(v))
     }
 
     fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::String(v.to_string()));
-        Ok(())
+        self.capture_value(FieldScalarValue::String(v.to_string()))
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::Bytes(v.to_vec()));
-        Ok(())
+        self.capture_value(FieldScalarValue::Bytes(v.to_vec()))
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        // Called for Option::None
-        if self.capturing {
-            // Capturing an explicit None for the target field
-            self.result = Some(FieldScalarValue::Option(None));
-            self.capturing = false;
-            self.expecting_option_inner = false; // Reset flag just in case
+        if self.ready_to_capture {
+            // Construct the nested None value based on the *current* nesting level.
+            let none_value =
+                wrap_in_options(FieldScalarValue::Option(None), self.option_nesting_level);
+            // Directly set the value, bypassing capture_value which would wrap again.
+            self.value = Some(none_value);
+            Ok(())
+        } else {
+            // Not capturing, None is just part of structure traversal.
+            Ok(())
         }
-        Ok(())
     }
 
-    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
-        // Called for Option::Some(value)
-        if self.capturing {
-            // Target field is an Option::Some. Set flag to wrap the *next* value captured.
-            self.expecting_option_inner = true;
-            // Don't reset self.capturing; the inner value serialization needs it.
+    fn serialize_some<T: ?Sized + Serialize>(self, value: &T) -> Result<Self::Ok, Self::Error> {
+        if self.ready_to_capture {
+            // Increment nesting level *before* serializing inner value.
+            let original_level = self.option_nesting_level;
+            self.option_nesting_level =
+                original_level
+                    .checked_add(1)
+                    .ok_or_else(|| EvaluateError::UnsupportedType {
+                        type_name: "Deeply Nested Option (>255 levels)",
+                    })?;
+            let result = value.serialize(&mut *self); // Serialize the inner value
+                                                      // Restore nesting level *after* serializing inner value.
+            self.option_nesting_level = original_level;
+            result
+        } else {
+            // Not capturing, just pass through serialization
+            value.serialize(&mut *self)
         }
-        // Serialize the inner value. This will call a serialize_* method which
-        // *might* capture the value (if self.capturing is still true) and will
-        // reset expecting_option_inner via capture_value.
-        let result = value.serialize(&mut *self);
-        // Reset flag *after* inner serialization, in case inner wasn't captured.
-        self.expecting_option_inner = false;
-        result
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        self.capture_value(FieldScalarValue::Unit);
-        Ok(())
+        self.capture_value(FieldScalarValue::Unit)
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-        self.serialize_unit()
+        self.capture_value(FieldScalarValue::Unit)
     }
 
     fn serialize_unit_variant(
@@ -308,8 +292,8 @@ impl Serializer for &mut FieldValueExtractorSerializer {
         T: ?Sized + Serialize,
     {
         // Capturing from inside enum variants is not supported.
-        if self.capturing {
-            self.capturing = false;
+        if self.ready_to_capture {
+            self.ready_to_capture = false;
         }
         Err(EvaluateError::UnsupportedVariant {
             variant_type: "newtype",
@@ -321,8 +305,8 @@ impl Serializer for &mut FieldValueExtractorSerializer {
     // itself cannot be a sequence, map, etc., it must be a scalar or Option<Scalar>.
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        if self.capturing {
-            self.capturing = false;
+        if self.ready_to_capture {
+            self.ready_to_capture = false;
             Err(EvaluateError::UnsupportedType {
                 type_name: "sequence",
             })
@@ -334,8 +318,8 @@ impl Serializer for &mut FieldValueExtractorSerializer {
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        if self.capturing {
-            self.capturing = false;
+        if self.ready_to_capture {
+            self.ready_to_capture = false;
             Err(EvaluateError::UnsupportedType { type_name: "tuple" })
         } else {
             // Skip the tuple content if not capturing.
@@ -348,8 +332,8 @@ impl Serializer for &mut FieldValueExtractorSerializer {
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        if self.capturing {
-            self.capturing = false;
+        if self.ready_to_capture {
+            self.ready_to_capture = false;
             Err(EvaluateError::UnsupportedType {
                 type_name: "tuple struct",
             })
@@ -366,8 +350,8 @@ impl Serializer for &mut FieldValueExtractorSerializer {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        if self.capturing {
-            self.capturing = false;
+        if self.ready_to_capture {
+            self.ready_to_capture = false;
         }
         Err(EvaluateError::UnsupportedVariant {
             variant_type: "tuple",
@@ -386,9 +370,9 @@ impl Serializer for &mut FieldValueExtractorSerializer {
         if self.current_path_index >= self.path.len() {
             // Path exhausted, but we got a map. This is only valid if we are NOT capturing the final value.
             // If we were capturing, it means the path pointed to a map, not a scalar.
-            if self.capturing {
+            if self.ready_to_capture {
                 // Path ended here, but it's a map, not a scalar.
-                self.capturing = false; // Stop capturing
+                self.ready_to_capture = false; // Stop capturing
                 return Err(EvaluateError::UnsupportedType {
                     type_name: "map", // Path pointed to a map
                 });
@@ -402,7 +386,7 @@ impl Serializer for &mut FieldValueExtractorSerializer {
         // If we are here, current_path_index < path.len().
         // We are expecting to traverse *into* this map.
         // Ensure capturing is true because we need to process keys/values.
-        self.capturing = true;
+        self.ready_to_capture = true;
 
         // Okay to proceed, return self to handle map key/value pairs
         Ok(self)
@@ -415,11 +399,11 @@ impl Serializer for &mut FieldValueExtractorSerializer {
     ) -> Result<Self::SerializeStruct, Self::Error> {
         // Check if path is exhausted OR if we are capturing the final value
         if self.current_path_index >= self.path.len() {
-            if self.capturing {
+            if self.ready_to_capture {
                 // Path exhausted, but we got a struct, and we are capturing.
                 // This means the final target path element pointed to a struct, not a scalar.
                 // Use capture_unsupported helper
-                self.capturing = false;
+                self.ready_to_capture = false;
                 Err(EvaluateError::UnsupportedType {
                     type_name: "struct",
                 })
@@ -440,8 +424,8 @@ impl Serializer for &mut FieldValueExtractorSerializer {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        if self.capturing {
-            self.capturing = false;
+        if self.ready_to_capture {
+            self.ready_to_capture = false;
         }
         Err(EvaluateError::UnsupportedVariant {
             variant_type: "struct",
@@ -454,72 +438,73 @@ impl ser::SerializeMap for &mut FieldValueExtractorSerializer {
     type Ok = ();
     type Error = EvaluateError;
 
-    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
-        // Check if we should even attempt to match the key
-        if !self.capturing || self.current_path_index >= self.path.len() {
-            self.current_map_key_match = Some(false);
-            return Ok(());
-        }
+    fn serialize_key<T: ?Sized + Serialize>(&mut self, key: &T) -> Result<(), Self::Error> {
+        // Reset key match state for each new key
+        self.current_map_key_match = None;
 
-        // Use StringKeySerializer to capture the key as a string
-        let mut key_serializer = StringKeySerializer { key: None };
-        key.serialize(&mut key_serializer)?;
-        let captured_key = key_serializer.key;
-        if let Some(key_str) = captured_key {
-            let expected_key = &self.path[self.current_path_index];
-            if key_str == *expected_key {
-                // Dereference expected_key
-                // Key matches the current path segment!
-                // Set flag, but DO NOT increment index here.
-                self.current_map_key_match = Some(true);
+        // Check if we are still traversing the path
+        if self.value.is_none() && self.current_path_index < self.path.len() {
+            // We need to compare this key against the current path segment.
+            // Serialize the key to a string to compare.
+            let mut key_serializer = StringKeySerializer { key: None };
+            key.serialize(&mut key_serializer)?;
+
+            if let Some(key_str) = key_serializer.key {
+                if key_str == self.path[self.current_path_index] {
+                    // Key matches the current path segment.
+                    self.current_map_key_match = Some(true);
+                } else {
+                    // Key does not match.
+                    self.current_map_key_match = Some(false);
+                }
             } else {
-                // Key does not match the current path segment
+                // Key wasn't a string, cannot match path segment.
                 self.current_map_key_match = Some(false);
+                // Potentially return an error? Or just skip?
+                // Let's just skip the corresponding value.
             }
         } else {
-            // Key was not a string, cannot match path segment
-            self.current_map_key_match = None; // Indicate key wasn't string/error
+            // Path exhausted or value already found, mark as no match.
+            self.current_map_key_match = Some(false);
         }
         Ok(())
     }
 
-    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
-        let key_match_status = self.current_map_key_match.take(); // Consume the match status
-
-        match key_match_status {
+    fn serialize_value<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), Self::Error> {
+        // Process based on whether the key matched
+        match self.current_map_key_match.take() {
+            // Consume the match state
             Some(true) => {
-                // Key matched! Serialize the value, advancing the path index for the nested call.
-                self.current_path_index += 1;
-                let res = value.serialize(&mut **self); // Recurse/capture
-                                                        // Backtrack the index *after* the value serialization is complete.
-                self.current_path_index -= 1;
-                res?; // Propagate any errors from the value serialization
+                // Key matched the current path segment.
+                self.current_path_index += 1; // Move deeper
+                let is_last_segment = self.current_path_index == self.path.len();
+
+                let result = if is_last_segment {
+                    // This is the target value.
+                    self.ready_to_capture = true;
+                    let res = value.serialize(&mut **self); // Serialize (may capture)
+                    self.ready_to_capture = false; // Reset flag
+                    res
+                } else {
+                    // Not the last segment, continue traversal.
+                    value.serialize(&mut **self) // Serialize without setting capture flag
+                };
+
+                self.current_path_index -= 1; // Move back up after processing/traversing
+                result
             }
             Some(false) | None => {
-                // Key did not match, wasn't a string, or error. Skip the value.
-                let mut dummy_serializer = FieldValueExtractorSerializer {
-                    path: vec![],
-                    current_path_index: 1, // Ensures path is considered "exhausted"
-                    result: None,
-                    capturing: false,
-                    expecting_option_inner: false, // Added default
-                    current_map_key_match: None,   // Added default
-                };
-                value.serialize(&mut dummy_serializer)?;
+                // Key didn't match, or state was missing. Skip this value.
+                // We still need to call serialize to allow Serde to process/skip the value's structure.
+                let mut dummy_serializer = FieldValueExtractorSerializer::new_nested(vec![]); // Dummy state
+                let _ = value.serialize(&mut dummy_serializer); // Ignore result/error
+                Ok(())
             }
         }
-        Ok(())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        // No error checking needed here. The extractor will determine if the
-        // full path was successfully resolved by checking the final result.
+        // No specific action needed when ending map serialization in this context.
         Ok(())
     }
 }
@@ -529,69 +514,63 @@ impl ser::SerializeStruct for &mut FieldValueExtractorSerializer {
     type Ok = ();
     type Error = EvaluateError;
 
-    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
+    fn serialize_field<T: ?Sized + Serialize>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error> {
         // If we've already found the result, skip remaining fields.
-        if self.result.is_some() {
+        if self.value.is_some() {
             return Ok(());
         }
 
-        // Check if path is valid and key matches the *current* segment
+        // Check if we are still traversing the path
         if self.current_path_index < self.path.len() {
-            let expected_key = &self.path[self.current_path_index];
-            if key == expected_key {
-                // Match found for the current path segment.
-                let is_last_segment = self.current_path_index == self.path.len() - 1;
+            // Compare the field key with the current path segment
+            if key == self.path[self.current_path_index] {
+                // Key matches.
+                self.current_path_index += 1; // Move deeper
+                let is_last_segment = self.current_path_index == self.path.len();
 
-                if is_last_segment {
-                    // This is the final segment. Set capturing and serialize the value.
-                    self.capturing = true;
-                    // Increment index *before* serializing value, so capture_value check works correctly.
-                    self.current_path_index += 1;
-                    let res = value.serialize(&mut **self);
-                    // Reset capturing flag defensively after serialization attempt.
-                    self.capturing = false;
-                    // Decrement index back *after* serialization of this field is done.
-                    // Allows subsequent fields at the *parent* level to be processed correctly if needed (though result is already set usually).
-                    self.current_path_index -= 1;
-                    res?; // Propagate error if serialization/capture failed.
+                let result = if is_last_segment {
+                    // This is the target field's value.
+                    self.ready_to_capture = true;
+                    let res = value.serialize(&mut **self); // Serialize (may capture)
+                    self.ready_to_capture = false; // Reset flag
+                    res
                 } else {
-                    // Not the last segment. Need to go deeper.
-                    // Increment index before recursing into the value.
-                    self.current_path_index += 1;
-                    // Serialize the nested value. This might call serialize_struct again.
-                    let res = value.serialize(&mut **self);
-                    // Decrement index *after* recursing. Backtrack for the next field at the current level.
-                    self.current_path_index -= 1;
-                    res?; // Propagate error if nested serialization failed.
-                }
-            } else {
-                // Key doesn't match the current path segment. Skip this field.
-                // Serialize the value anyway to allow Serde to skip its content.
-                // Ensure capturing is false during the skip.
-                let was_capturing = self.capturing;
-                self.capturing = false;
-                let _ = value.serialize(&mut **self); // Ignore result/errors for non-target fields
-                self.capturing = was_capturing; // Restore capturing state if it was somehow true?
+                    // Not the last segment, continue traversal into the value.
+                    value.serialize(&mut **self) // Serialize without setting capture flag
+                };
+
+                self.current_path_index -= 1; // Move back up after processing/traversing
+                return result; // Return result of serialization (could be error)
             }
-        } else {
-            // current_path_index >= path.len(). This shouldn't be reached if serialize_struct check works.
-            // Means we are serializing fields after the target path was fully traversed or failed.
-            // We can simply skip serializing further fields in this struct.
-            // However, Serde expects all fields to be serialized, so we still call serialize.
-            let _ = value.serialize(&mut **self);
         }
+
+        // If key didn't match, or path index is beyond length, or value already found: skip.
+        // We don't need to explicitly serialize to skip for structs like we might for maps/seqs,
+        // just returning Ok allows SerializeStruct loop to continue to the next field.
         Ok(())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        // End of struct. If we traversed the whole path but didn't capture a value,
-        // it means the final field was not found or was an unsupported type.
-        // The `into_result` method combined with initial state handles FieldNotFound.
-        // Errors during traversal (e.g., UnsupportedType) are returned earlier.
-        Ok(())
+        // Check if path wasn't fully resolved after struct ended (if we were expecting more nesting)
+        if self.value.is_none()
+            && self.current_path_index > 0
+            && self.current_path_index < self.path.len()
+        {
+            // We finished serializing a struct, but we were expecting more path segments.
+            // This indicates the path was invalid for this structure.
+            // We should have already bailed in serialize_struct or serialize_map if the path ended early.
+            // This check might be redundant but acts as a safeguard.
+            // Let's return FieldNotFound based on the *expected* next segment.
+            Err(EvaluateError::NestedFieldNotFound {
+                path: self.path.clone(),
+            })
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -236,7 +236,7 @@ impl Serializer for &mut FieldValueExtractorSerializer {
             self.option_nesting_level =
                 original_level
                     .checked_add(1)
-                    .ok_or_else(|| EvaluateError::UnsupportedType {
+                    .ok_or(EvaluateError::UnsupportedType {
                         type_name: "Deeply Nested Option (>255 levels)",
                     })?;
             let result = value.serialize(&mut *self); // Serialize the inner value

--- a/tests/field.rs
+++ b/tests/field.rs
@@ -298,3 +298,115 @@ fn test_extract_map_field_unsupported() {
         result
     );
 }
+
+#[test]
+fn test_nested_option_u32_some_some() {
+    #[derive(Serialize)]
+    struct TestStruct {
+        nested_option_u32: Option<Option<u32>>,
+    }
+
+    let test_struct = TestStruct {
+        nested_option_u32: Some(Some(123u32)),
+    };
+
+    let result = FieldExtractor::new("nested_option_u32").evaluate(&test_struct);
+    assert_eq!(
+        result,
+        Ok(FieldScalarValue::Option(Some(Box::new(
+            FieldScalarValue::Option(Some(Box::new(FieldScalarValue::U32(123))))
+        ))))
+    );
+}
+
+#[test]
+fn test_nested_option_u32_some_none() {
+    #[derive(Serialize)]
+    struct TestStruct {
+        nested_option_u32: Option<Option<u32>>,
+    }
+
+    let test_struct = TestStruct {
+        nested_option_u32: Some(None),
+    };
+
+    let result = FieldExtractor::new("nested_option_u32").evaluate(&test_struct);
+    assert_eq!(
+        result,
+        Ok(FieldScalarValue::Option(Some(Box::new(
+            FieldScalarValue::Option(None)
+        ))))
+    );
+}
+
+#[test]
+fn test_nested_option_u32_none() {
+    #[derive(Serialize)]
+    struct TestStruct {
+        nested_option_u32: Option<Option<u32>>,
+    }
+
+    let test_struct = TestStruct {
+        nested_option_u32: None,
+    };
+
+    let result = FieldExtractor::new("nested_option_u32").evaluate(&test_struct);
+    assert_eq!(result, Ok(FieldScalarValue::Option(None)));
+}
+
+#[test]
+fn test_nested_option_string_some_some() {
+    #[derive(Serialize)]
+    struct TestStruct {
+        nested_option_string: Option<Option<String>>,
+    }
+
+    let test_struct = TestStruct {
+        nested_option_string: Some(Some("hello".to_string())),
+    };
+
+    let result = FieldExtractor::new("nested_option_string").evaluate(&test_struct);
+    assert_eq!(
+        result,
+        Ok(FieldScalarValue::Option(Some(Box::new(
+            FieldScalarValue::Option(Some(Box::new(FieldScalarValue::String(
+                "hello".to_string()
+            ))))
+        ))))
+    );
+}
+
+#[test]
+fn test_nested_option_string_some_none() {
+    #[derive(Serialize)]
+    struct TestStruct {
+        nested_option_string: Option<Option<String>>,
+    }
+
+    let test_struct = TestStruct {
+        nested_option_string: Some(None),
+    };
+
+    let result = FieldExtractor::new("nested_option_string").evaluate(&test_struct);
+    assert_eq!(
+        result,
+        Ok(FieldScalarValue::Option(Some(Box::new(
+            FieldScalarValue::Option(None)
+        ))))
+    );
+}
+
+#[test]
+fn test_nested_option_string_none() {
+    #[derive(Serialize)]
+    struct TestStruct {
+        nested_option_string: Option<Option<String>>,
+    }
+
+    let test_struct = TestStruct {
+        nested_option_string: None,
+    };
+
+    let result = FieldExtractor::new("nested_option_string").evaluate(&test_struct);
+    assert_eq!(result, Ok(FieldScalarValue::Option(None)));
+}


### PR DESCRIPTION
This pull request enhances the `serde-evaluate` library by improving its documentation, adding new features, and expanding test coverage. The most significant changes include detailed usage examples in the `README.md` and `src/lib.rs`, the addition of support for nested `Option` types, and new tests to validate this functionality.

### Documentation Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R99): Expanded with an overview, feature highlights, and detailed usage examples for `FieldExtractor` and `NestedFieldExtractor`, including code snippets for extracting top-level and nested fields.
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L3-R21): Updated with a "Features" section describing supported scalar types, nested field access, `Option` handling, and error handling. Added inline usage examples similar to those in the `README.md`. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L3-R21) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R31-R110)

### Feature Additions:
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L3-R21): Introduced support for nested `Option` types, allowing the library to correctly extract and represent values like `Option<Option<T>>`.

### Test Coverage:
* [`tests/field.rs`](diffhunk://#diff-2afc1971ed0a4f27e0c24641df6d60655da8999e3d4a01193c13729041b55145R301-R412): Added multiple tests to validate the extraction of nested `Option` types, including cases for `Some(Some(value))`, `Some(None)`, and `None` for both `u32` and `String` types.