### PR TITLE
fix: prevent serialize_map from prematurely capturing intermediate path scalars

### DIFF
--- a/src/serializer/extractor.rs
+++ b/src/serializer/extractor.rs
@@ -350,7 +350,6 @@ impl<'a> Serializer for &'a mut FieldValueExtractorSerializer {
             }
         }
 
-        self.state.ready_to_capture = true;
         Ok(self)
     }
 

--- a/tests/field.rs
+++ b/tests/field.rs
@@ -405,3 +405,228 @@ fn test_nested_option_string_none() {
     let result = FieldExtractor::new("nested_option_string").evaluate(&test_struct);
     assert_eq!(result, Ok(FieldScalarValue::Option(None)));
 }
+
+// =============================================================================
+// Enum variant handling
+// =============================================================================
+
+#[derive(Serialize)]
+enum Status {
+    Active,
+    #[allow(dead_code)]
+    Inactive,
+}
+
+#[derive(Serialize)]
+enum Payload {
+    Data(String),
+}
+
+#[derive(Serialize)]
+enum Event {
+    Click(i32, i32),
+}
+
+#[derive(Serialize)]
+enum Task {
+    Todo { id: u32, title: String },
+}
+
+#[test]
+fn test_extract_unit_variant() {
+    #[derive(Serialize)]
+    struct Record {
+        status: Status,
+    }
+    let record = Record {
+        status: Status::Active,
+    };
+    let result = FieldExtractor::new("status").evaluate(&record);
+    assert_eq!(result, Ok(FieldScalarValue::Unit));
+}
+
+#[test]
+fn test_extract_newtype_variant_rejected() {
+    #[derive(Serialize)]
+    struct Record {
+        payload: Payload,
+    }
+    let record = Record {
+        payload: Payload::Data("hello".to_string()),
+    };
+    let result = FieldExtractor::new("payload").evaluate(&record);
+    assert!(
+        matches!(
+            result,
+            Err(EvaluateError::UnsupportedVariant {
+                variant_type: "newtype"
+            })
+        ),
+        "Expected UnsupportedVariant newtype, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_extract_tuple_variant_rejected() {
+    #[derive(Serialize)]
+    struct Record {
+        event: Event,
+    }
+    let record = Record {
+        event: Event::Click(10, 20),
+    };
+    let result = FieldExtractor::new("event").evaluate(&record);
+    assert!(
+        matches!(
+            result,
+            Err(EvaluateError::UnsupportedVariant {
+                variant_type: "tuple"
+            })
+        ),
+        "Expected UnsupportedVariant tuple, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_extract_struct_variant_rejected() {
+    #[derive(Serialize)]
+    struct Record {
+        task: Task,
+    }
+    let record = Record {
+        task: Task::Todo {
+            id: 1,
+            title: "test".to_string(),
+        },
+    };
+    let result = FieldExtractor::new("task").evaluate(&record);
+    assert!(
+        matches!(
+            result,
+            Err(EvaluateError::UnsupportedVariant {
+                variant_type: "struct"
+            })
+        ),
+        "Expected UnsupportedVariant struct, got {:?}",
+        result
+    );
+}
+
+// =============================================================================
+// Newtype struct transparency
+// =============================================================================
+
+#[test]
+fn test_extract_newtype_struct_field() {
+    #[derive(Serialize)]
+    struct UserId(u64);
+
+    #[derive(Serialize)]
+    struct User {
+        id: UserId,
+        name: String,
+    }
+
+    let user = User {
+        id: UserId(12345),
+        name: "Alice".to_string(),
+    };
+    let result = FieldExtractor::new("id").evaluate(&user);
+    assert_eq!(result, Ok(FieldScalarValue::U64(12345)));
+}
+
+#[test]
+fn test_nested_extract_through_newtype_struct() {
+    #[derive(Serialize)]
+    struct Inner {
+        value: i32,
+    }
+
+    #[derive(Serialize)]
+    struct Wrapper(Inner);
+
+    #[derive(Serialize)]
+    struct Outer {
+        wrapped: Wrapper,
+    }
+
+    let data = Outer {
+        wrapped: Wrapper(Inner { value: 99 }),
+    };
+    let extractor =
+        serde_evaluate::extractor::NestedFieldExtractor::new_from_path(&["wrapped", "value"])
+            .unwrap();
+    let result = extractor.evaluate(&data);
+    assert_eq!(result, Ok(FieldScalarValue::I32(99)));
+}
+
+// =============================================================================
+// Triple-nested Options
+// =============================================================================
+
+#[test]
+fn test_triple_nested_option_all_some() {
+    #[derive(Serialize)]
+    struct Record {
+        val: Option<Option<Option<u32>>>,
+    }
+    let record = Record {
+        val: Some(Some(Some(42))),
+    };
+    let result = FieldExtractor::new("val").evaluate(&record);
+    assert_eq!(
+        result,
+        Ok(FieldScalarValue::Option(Some(Box::new(
+            FieldScalarValue::Option(Some(Box::new(FieldScalarValue::Option(Some(Box::new(
+                FieldScalarValue::U32(42)
+            ))))))
+        ))))
+    );
+}
+
+#[test]
+fn test_triple_nested_option_some_some_none() {
+    #[derive(Serialize)]
+    struct Record {
+        val: Option<Option<Option<u32>>>,
+    }
+    let record = Record {
+        val: Some(Some(None)),
+    };
+    let result = FieldExtractor::new("val").evaluate(&record);
+    assert_eq!(
+        result,
+        Ok(FieldScalarValue::Option(Some(Box::new(
+            FieldScalarValue::Option(Some(Box::new(FieldScalarValue::Option(None))))
+        ))))
+    );
+}
+
+#[test]
+fn test_triple_nested_option_some_none() {
+    #[derive(Serialize)]
+    struct Record {
+        val: Option<Option<Option<u32>>>,
+    }
+    let record = Record { val: Some(None) };
+    let result = FieldExtractor::new("val").evaluate(&record);
+    assert_eq!(
+        result,
+        Ok(FieldScalarValue::Option(Some(Box::new(
+            FieldScalarValue::Option(None)
+        ))))
+    );
+}
+
+#[test]
+fn test_triple_nested_option_none() {
+    #[derive(Serialize)]
+    struct Record {
+        val: Option<Option<Option<u32>>>,
+    }
+    let record = Record { val: None };
+    let result = FieldExtractor::new("val").evaluate(&record);
+    assert_eq!(result, Ok(FieldScalarValue::Option(None)));
+}

--- a/tests/json_value.rs
+++ b/tests/json_value.rs
@@ -557,3 +557,27 @@ fn test_nested_extract_struct_json_value_intermediate_scalar_should_error() {
         result
     );
 }
+
+// =============================================================================
+// Deep JSON nesting (4+ levels)
+// =============================================================================
+
+#[test]
+fn test_nested_extract_json_five_levels_deep() {
+    let json = serde_json::json!({"a": {"b": {"c": {"d": {"e": 42}}}}});
+    let extractor = NestedFieldExtractor::new_from_path(&["a", "b", "c", "d", "e"]).unwrap();
+    let result = extractor.evaluate(&json);
+    assert_eq!(result, Ok(FieldScalarValue::U64(42)));
+}
+
+// =============================================================================
+// Bare JSON object (no struct wrapper)
+// =============================================================================
+
+#[test]
+fn test_extract_field_from_bare_json_object() {
+    let json = serde_json::json!({"name": "test", "count": 42});
+    let extractor = FieldExtractor::new("name");
+    let result = extractor.evaluate(&json);
+    assert_eq!(result, Ok(FieldScalarValue::String("test".to_string())));
+}

--- a/tests/json_value.rs
+++ b/tests/json_value.rs
@@ -447,3 +447,113 @@ fn test_extract_field_after_complex_json_value() {
     let result = extractor.evaluate(&record);
     assert_eq!(result, Ok(FieldScalarValue::String("target".to_string())));
 }
+
+// =============================================================================
+// NestedFieldExtractor: intermediate path is scalar (not object/map)
+// =============================================================================
+
+#[test]
+fn test_nested_extract_json_intermediate_scalar_should_error() {
+    // Path ["details", "rating"] but "details" is a string, not an object.
+    // Should error with NestedFieldNotFound, not return the string.
+    let json = serde_json::json!({"details": "not_an_object", "score": 42});
+    let extractor = NestedFieldExtractor::new_from_path(&["details", "rating"]).unwrap();
+    let result = extractor.evaluate(&json);
+    assert!(
+        matches!(result, Err(EvaluateError::NestedFieldNotFound { .. })),
+        "Expected NestedFieldNotFound when intermediate path is scalar, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_nested_extract_json_intermediate_number_should_error() {
+    // Path ["score", "sub"] but "score" is a number.
+    let json = serde_json::json!({"score": 42, "name": "test"});
+    let extractor = NestedFieldExtractor::new_from_path(&["score", "sub"]).unwrap();
+    let result = extractor.evaluate(&json);
+    assert!(
+        matches!(result, Err(EvaluateError::NestedFieldNotFound { .. })),
+        "Expected NestedFieldNotFound when intermediate path is number, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_nested_extract_json_intermediate_bool_should_error() {
+    // Path ["active", "sub"] but "active" is a bool.
+    let json = serde_json::json!({"active": true});
+    let extractor = NestedFieldExtractor::new_from_path(&["active", "sub"]).unwrap();
+    let result = extractor.evaluate(&json);
+    assert!(
+        matches!(result, Err(EvaluateError::NestedFieldNotFound { .. })),
+        "Expected NestedFieldNotFound when intermediate path is bool, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_nested_extract_json_intermediate_null_should_error() {
+    // Path ["data", "sub"] but "data" is null.
+    let json = serde_json::json!({"data": null});
+    let extractor = NestedFieldExtractor::new_from_path(&["data", "sub"]).unwrap();
+    let result = extractor.evaluate(&json);
+    assert!(
+        matches!(result, Err(EvaluateError::NestedFieldNotFound { .. })),
+        "Expected NestedFieldNotFound when intermediate path is null, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_nested_extract_json_intermediate_array_should_error() {
+    // Path ["details", "sub"] but "details" is an array, not an object.
+    let json = serde_json::json!({"details": [1, 2, 3]});
+    let extractor = NestedFieldExtractor::new_from_path(&["details", "sub"]).unwrap();
+    let result = extractor.evaluate(&json);
+    assert!(
+        matches!(result, Err(EvaluateError::NestedFieldNotFound { .. })),
+        "Expected NestedFieldNotFound when intermediate path is array, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_nested_extract_json_deeper_intermediate_scalar_should_error() {
+    // Path ["a", "b", "c"] but "b" is a scalar, not an object.
+    let json = serde_json::json!({"a": {"b": "scalar_not_object"}});
+    let extractor = NestedFieldExtractor::new_from_path(&["a", "b", "c"]).unwrap();
+    let result = extractor.evaluate(&json);
+    assert!(
+        matches!(result, Err(EvaluateError::NestedFieldNotFound { .. })),
+        "Expected NestedFieldNotFound when deeper intermediate path is scalar, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_nested_extract_json_same_key_at_multiple_levels() {
+    // Path ["a", "a"] on {"a": {"a": 42}} — same key name at both levels.
+    let json = serde_json::json!({"a": {"a": 42}});
+    let extractor = NestedFieldExtractor::new_from_path(&["a", "a"]).unwrap();
+    let result = extractor.evaluate(&json);
+    assert_eq!(result, Ok(FieldScalarValue::U64(42)));
+}
+
+#[test]
+fn test_nested_extract_struct_json_value_intermediate_scalar_should_error() {
+    // Struct field "metadata" is a serde_json::Value containing {"config": "flat_string"}.
+    // Path ["metadata", "config", "region"] should error because "config" is a string.
+    let record = RecordWithJsonValue {
+        id: 1,
+        name: "test".to_string(),
+        metadata: serde_json::json!({"config": "flat_string"}),
+    };
+    let extractor = NestedFieldExtractor::new_from_path(&["metadata", "config", "region"]).unwrap();
+    let result = extractor.evaluate(&record);
+    assert!(
+        matches!(result, Err(EvaluateError::NestedFieldNotFound { .. })),
+        "Expected NestedFieldNotFound for struct→JSON intermediate scalar, got {:?}",
+        result
+    );
+}

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -330,3 +330,133 @@ fn test_extract_list_with_option_elements() {
         ]
     );
 }
+
+// =============================================================================
+// NestedListFieldExtractor error paths
+// =============================================================================
+
+#[test]
+fn test_nested_list_intermediate_scalar_error() {
+    #[derive(Serialize)]
+    struct Record {
+        count: i32,
+    }
+    let record = Record { count: 42 };
+    let extractor = NestedListFieldExtractor::new_from_path(&["count", "items"]).unwrap();
+    let result = extractor.evaluate(&record);
+    assert!(
+        matches!(result, Err(EvaluateError::NestedFieldNotFound { .. })),
+        "Expected NestedFieldNotFound for scalar intermediate in list path, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_nested_list_intermediate_not_found() {
+    #[derive(Serialize)]
+    struct Record {
+        name: String,
+    }
+    let record = Record {
+        name: "test".to_string(),
+    };
+    let extractor = NestedListFieldExtractor::new_from_path(&["nonexistent", "items"]).unwrap();
+    let result = extractor.evaluate(&record);
+    assert!(
+        matches!(result, Err(EvaluateError::NestedFieldNotFound { .. })),
+        "Expected NestedFieldNotFound for missing intermediate in list path, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_nested_list_three_levels_deep() {
+    #[derive(Serialize)]
+    struct Level3 {
+        tags: Vec<String>,
+    }
+    #[derive(Serialize)]
+    struct Level2 {
+        deeper: Level3,
+    }
+    #[derive(Serialize)]
+    struct Level1 {
+        data: Level2,
+    }
+
+    let record = Level1 {
+        data: Level2 {
+            deeper: Level3 {
+                tags: vec!["x".to_string(), "y".to_string(), "z".to_string()],
+            },
+        },
+    };
+    let extractor = NestedListFieldExtractor::new_from_path(&["data", "deeper", "tags"]).unwrap();
+    let result = extractor.evaluate(&record).unwrap();
+    assert_eq!(
+        result,
+        vec![
+            FieldScalarValue::String("x".to_string()),
+            FieldScalarValue::String("y".to_string()),
+            FieldScalarValue::String("z".to_string()),
+        ]
+    );
+}
+
+// =============================================================================
+// List of enum variants (ScalarCaptureSerializer rejection)
+// =============================================================================
+
+#[test]
+fn test_list_of_newtype_variants_rejected() {
+    #[derive(Serialize)]
+    enum MyEnum {
+        Data(String),
+    }
+    #[derive(Serialize)]
+    struct Record {
+        items: Vec<MyEnum>,
+    }
+    let record = Record {
+        items: vec![MyEnum::Data("hello".to_string())],
+    };
+    let extractor = ListFieldExtractor::new("items");
+    let result = extractor.evaluate(&record);
+    assert!(
+        matches!(
+            result,
+            Err(EvaluateError::UnsupportedVariant {
+                variant_type: "newtype"
+            })
+        ),
+        "Expected UnsupportedVariant newtype in list, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_list_of_tuple_variants_rejected() {
+    #[derive(Serialize)]
+    enum MyEnum {
+        Pair(i32, i32),
+    }
+    #[derive(Serialize)]
+    struct Record {
+        items: Vec<MyEnum>,
+    }
+    let record = Record {
+        items: vec![MyEnum::Pair(1, 2)],
+    };
+    let extractor = ListFieldExtractor::new("items");
+    let result = extractor.evaluate(&record);
+    assert!(
+        matches!(
+            result,
+            Err(EvaluateError::UnsupportedVariant {
+                variant_type: "tuple"
+            })
+        ),
+        "Expected UnsupportedVariant tuple in list, got {:?}",
+        result
+    );
+}

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -307,3 +307,34 @@ fn test_extract_nested_map_field() {
         result_simple_missing
     );
 }
+
+#[test]
+fn test_extract_nested_pure_maps() {
+    // BTreeMap<String, BTreeMap<String, BTreeMap<String, i32>>>
+    // Tests map→map→map→scalar traversal.
+    let mut leaf = BTreeMap::new();
+    leaf.insert("leaf".to_string(), 42);
+
+    let mut inner = BTreeMap::new();
+    inner.insert("inner".to_string(), leaf);
+
+    let mut outer: BTreeMap<String, BTreeMap<String, BTreeMap<String, i32>>> = BTreeMap::new();
+    outer.insert("outer".to_string(), inner);
+
+    let extractor = NestedFieldExtractor::new_from_path(&["outer", "inner", "leaf"]).unwrap();
+    let result = extractor.evaluate(&outer);
+    assert_eq!(result, Ok(FieldScalarValue::I32(42)));
+
+    // Missing key at deepest level
+    let extractor_missing =
+        NestedFieldExtractor::new_from_path(&["outer", "inner", "missing"]).unwrap();
+    let result_missing = extractor_missing.evaluate(&outer);
+    assert!(
+        matches!(
+            result_missing,
+            Err(EvaluateError::NestedFieldNotFound { .. })
+        ),
+        "Expected NestedFieldNotFound for missing leaf key, got {:?}",
+        result_missing
+    );
+}

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -367,8 +367,8 @@ fn test_extract_map_with_non_string_keys_error() {
     let extractor = NestedFieldExtractor::new_from_path(&["int_map", "42"]).unwrap();
     let result = extractor.evaluate(&record);
     assert!(
-        result.is_err(),
-        "Expected error for non-string map keys, got {:?}",
+        matches!(result, Err(EvaluateError::UnsupportedType { .. })),
+        "Expected UnsupportedType error for non-string map keys, got {:?}",
         result
     );
 }

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -338,3 +338,37 @@ fn test_extract_nested_pure_maps() {
         result_missing
     );
 }
+
+#[test]
+fn test_extract_from_empty_map_intermediate() {
+    let mut data_map: BTreeMap<String, BTreeMap<String, i32>> = BTreeMap::new();
+    data_map.insert("empty_map".to_string(), BTreeMap::new());
+
+    let extractor = NestedFieldExtractor::new_from_path(&["empty_map", "key"]).unwrap();
+    let result = extractor.evaluate(&data_map);
+    assert!(
+        matches!(result, Err(EvaluateError::NestedFieldNotFound { .. })),
+        "Expected NestedFieldNotFound for empty map intermediate, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_extract_map_with_non_string_keys_error() {
+    #[derive(Serialize)]
+    struct Record {
+        int_map: BTreeMap<i32, String>,
+    }
+
+    let mut map = BTreeMap::new();
+    map.insert(42, "value".to_string());
+    let record = Record { int_map: map };
+
+    let extractor = NestedFieldExtractor::new_from_path(&["int_map", "42"]).unwrap();
+    let result = extractor.evaluate(&record);
+    assert!(
+        result.is_err(),
+        "Expected error for non-string map keys, got {:?}",
+        result
+    );
+}


### PR DESCRIPTION
## Summary

- **Bug fix**: `serialize_map` was setting `ready_to_capture=true` on entry for any map with remaining path segments. This caused `NestedFieldExtractor` to return scalar values at intermediate path positions instead of erroring. For example, path `["details", "rating"]` on `{"details": "not_an_object"}` returned `Ok(String("not_an_object"))` instead of `Err(NestedFieldNotFound)`.
- **Fix**: Remove one line from `src/serializer/extractor.rs` — `ready_to_capture` is now only set in `serialize_value`/`serialize_field`, consistent with `serialize_struct`.
- **25 new tests** covering the fix and previously untested serializer code paths: intermediate scalars/arrays/null in JSON, enum variant rejection, newtype struct transparency, triple-nested Options, nested list error paths, bare JSON object extraction, empty map traversal, non-string map keys, and 5-level deep JSON nesting.

## Test plan

- [x] `cargo test` — all 112 tests pass (up from 87)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)